### PR TITLE
chore: Switch to Dependabot multi-ecosystem group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,17 @@
 version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: monthly
 
-  - package-ecosystem: npm
-    directory: /
+multi-ecosystem-groups:
+  repo-dependencies:
     schedule:
-      interval: monthly
+      interval: "monthly"
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "repo-dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "repo-dependencies"


### PR DESCRIPTION
### What and why?

📦 This PR enables the `multi-ecosystem-groups` setting in Dependabot to simplify dependency management and consolidate updates into a single monthly PR.

### How?

Replaced separate update configurations with one [`multi-ecosystem-group`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#multi-ecosystem-group).