### PR TITLE
[dependabot npm disable] Temporarily disable npm version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,15 @@
 version: 2
-
 multi-ecosystem-groups:
   repo-dependencies:
     schedule:
       interval: "monthly"
-
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "repo-dependencies"
-
   - package-ecosystem: "npm"
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "repo-dependencies"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
This PR temporarily disables Dependabot **npm version updates** by setting `open-pull-requests-limit: 0` for all `package-ecosystem: npm` entries.

Use the matching `enable` script (or manually remove that field) to re-enable npm version updates later.